### PR TITLE
Fixes on specs for places and producers

### DIFF
--- a/spec/requests/api/v1/places_spec.rb
+++ b/spec/requests/api/v1/places_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Api::V1::PlacesController, type: :request do
     before { get '/v1/places' }
 
     it 'should return places' do
-      expect(response).not_to be_empty
-      expect(response.size).to eq(10)
+      expect(json).not_to be_empty
+      expect(json.size).to eq(10)
     end
 
     it 'should return status code 200' do
@@ -22,8 +22,8 @@ RSpec.describe Api::V1::PlacesController, type: :request do
 
     context 'when the record exists' do
       it 'should return the place' do
-        expect(response).not_to be_empty
-        expect(response['id']).to eq(place_id)
+        expect(json).not_to be_empty
+        expect(json['id']).to eq(place_id)
       end
 
       it 'should return status code 200' do
@@ -45,15 +45,15 @@ RSpec.describe Api::V1::PlacesController, type: :request do
   end
 
   describe 'POST /v1/places' do
-    let(:valid_attributes) { {tag: 'My farm', lat: '-74.110642', lon: '4.712504'} }
+    let(:valid_attributes) { {tag: 'My farm', lat: -74.110642, lon: 4.712504} }
 
     context 'when the request is valid' do
       before { post '/v1/places', params: valid_attributes }
 
       it 'should create a place' do
-        expect(response['tag']).to eq('My farm')
-        expect(response['lat']).to eq('-74.110642')
-        expect(response['lon']).to eq('4.712504')
+        expect(json['tag']).to eq('My farm')
+        expect(json['lat']).to eq(-74.110642)
+        expect(json['lon']).to eq(4.712504)
       end
 
       it 'should return status code 201' do

--- a/spec/requests/api/v1/producers_spec.rb
+++ b/spec/requests/api/v1/producers_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Api::V1::ProducersController, type: :request do
     before { get '/v1/producers' }
 
     it 'should return producers' do
-      expect(response).not_to be_empty
-      expect(response.size).to eq(10)
+      expect(json).not_to be_empty
+      expect(json.size).to eq(10)
     end
 
     it 'should return status code 200' do
@@ -22,8 +22,8 @@ RSpec.describe Api::V1::ProducersController, type: :request do
 
     context 'when the record exists' do
       it 'should return the producer' do
-        expect(response).not_to be_empty
-        expect(response['id']).to eq(producer_id)
+        expect(json).not_to be_empty
+        expect(json['id']).to eq(producer_id)
       end
 
       it 'should return status code 200' do
@@ -53,11 +53,10 @@ RSpec.describe Api::V1::ProducersController, type: :request do
       before { post '/v1/producers', params: valid_attributes }
 
       it 'should create the producer' do
-        pp(valid_attributes)
-        expect(response['first_name']).to eq('John')
-        expect(response['last_name']).to eq('Doe')
-        expect(response['username']).to eq('jdoe')
-        expect(response['password']).to eq('1234567890')
+        expect(json['first_name']).to eq('John')
+        expect(json['last_name']).to eq('Doe')
+        expect(json['username']).to eq('jdoe')
+        expect(json['password']).to eq('1234567890')
       end
 
       it 'should return status code 201' do


### PR DESCRIPTION
The problem was that I was testing over a method rather than the
response itself. It's quite different to test a `response` than a
`json`. Both have differences. If it's required to use `response`, then
the call must be `response.body` or `json`, for example
`response.body.size` is equal to `json.size`.

https://trello.com/c/sb19gp7b/