### PR TITLE
Fixing model and request specs for `Routes`

### DIFF
--- a/spec/models/place_spec.rb
+++ b/spec/models/place_spec.rb
@@ -8,4 +8,6 @@ RSpec.describe Place, type: :model do
 
   # Ensure has many Producers
   it { should have_many(:producers) }
+  it { should have_many(:origins) }
+  it { should have_many(:destinations) }
 end

--- a/spec/models/route_spec.rb
+++ b/spec/models/route_spec.rb
@@ -2,4 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Route, type: :model do
   # Ensure Route has relations to Places for both Origin and Destination
+
+  it { should belong_to(:origin) }
+  it { should belong_to(:destination) }
 end

--- a/spec/requests/api/v1/routes_spec.rb
+++ b/spec/requests/api/v1/routes_spec.rb
@@ -53,8 +53,8 @@ RSpec.describe Api::V1::RoutesController, type: :request do
       before { post '/v1/routes', params: valid_attributes }
 
       it 'should create the route' do
-        expect(json['origin']).to eq(origin.id)
-        expect(json['destination']).to eq(destination.id)
+        expect(json['origin_id']).to eq(origin.id)
+        expect(json['destination_id']).to eq(destination.id)
       end
 
       it 'should return status code 201' do


### PR DESCRIPTION
There was a problem with the way rspec demands this type of associations
must be done and also in the way the migrations were done in the test
database.

I also realized there is no need to execute `bundle exec rspec`,
executing `rspec` is enough.

https://trello.com/c/8APDidfs/