### PR TITLE
Adding active model serializer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem 'puma', '~> 3.7'
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 gem 'rack-cors'
+gem 'active_model_serializers'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,11 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    active_model_serializers (0.10.5)
+      actionpack (>= 4.1, < 6)
+      activemodel (>= 4.1, < 6)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.2)
     activejob (5.1.0.rc1)
       activesupport (= 5.1.0.rc1)
       globalid (>= 0.3.6)
@@ -41,6 +46,8 @@ GEM
     arel (8.0.0)
     builder (3.2.3)
     byebug (9.0.6)
+    case_transform (0.2)
+      activesupport
     concurrent-ruby (1.0.5)
     database_cleaner (1.5.3)
     diff-lcs (1.3)
@@ -57,6 +64,7 @@ GEM
       activesupport (>= 4.1.0)
     hirb (0.7.3)
     i18n (0.8.1)
+    jsonapi-renderer (0.1.2)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -151,6 +159,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_model_serializers
   byebug
   database_cleaner
   factory_girl_rails (~> 4.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::API
+  include ActionController::Serialization
   include Response
   include ExceptionHandler
 

--- a/app/controllers/concerns/response.rb
+++ b/app/controllers/concerns/response.rb
@@ -1,5 +1,5 @@
 module Response
   def json_response(object, status = :ok)
-    render json: object, status: status
+    render json: object, status: status, root: 'data'
   end
 end

--- a/app/serializers/crop_log_serializer.rb
+++ b/app/serializers/crop_log_serializer.rb
@@ -1,0 +1,3 @@
+class CropLogSerializer < ActiveModel::Serializer
+  attributes :id, :description, :created_at
+end

--- a/app/serializers/crop_serializer.rb
+++ b/app/serializers/crop_serializer.rb
@@ -1,0 +1,4 @@
+class CropSerializer < ActiveModel::Serializer
+  attributes :id, :sow_date, :harvest_date, :container_id, :product_id, :producer_id
+  has_many :crop_logs
+end

--- a/app/serializers/package_serializer.rb
+++ b/app/serializers/package_serializer.rb
@@ -1,0 +1,3 @@
+class PackageSerializer < ActiveModel::Serializer
+  attributes :id, :parent_id, :crop_id, :route_id, :quantity
+end

--- a/app/serializers/place_serializer.rb
+++ b/app/serializers/place_serializer.rb
@@ -1,0 +1,3 @@
+class PlaceSerializer < ActiveModel::Serializer
+  attributes :id, :tag, :lat, :lon
+end

--- a/app/serializers/producer_serializer.rb
+++ b/app/serializers/producer_serializer.rb
@@ -1,0 +1,3 @@
+class ProducerSerializer < ActiveModel::Serializer
+  attributes :id, :first_name, :last_name, :username
+end

--- a/app/serializers/product_serializer.rb
+++ b/app/serializers/product_serializer.rb
@@ -1,0 +1,3 @@
+class ProductSerializer < ActiveModel::Serializer
+  attributes :id, :name
+end

--- a/app/serializers/route_log_serializer.rb
+++ b/app/serializers/route_log_serializer.rb
@@ -1,0 +1,3 @@
+class RouteLogSerializer < ActiveModel::Serializer
+  attributes :id, :temperature, :humidity, :lat, :lon
+end

--- a/app/serializers/route_serializer.rb
+++ b/app/serializers/route_serializer.rb
@@ -1,0 +1,4 @@
+class RouteSerializer < ActiveModel::Serializer
+  attributes :id, :origin_id, :destination_id
+  has_many :route_logs
+end

--- a/app/serializers/warehouse_serializer.rb
+++ b/app/serializers/warehouse_serializer.rb
@@ -1,0 +1,3 @@
+class WarehouseSerializer < ActiveModel::Serializer
+  attributes :id, :name, :username
+end

--- a/config/initializers/active_model_serializers.rb
+++ b/config/initializers/active_model_serializers.rb
@@ -1,0 +1,1 @@
+ActiveModel::Serializer.config.adapter =:json


### PR DESCRIPTION
I've added the active model serializer gem and defined some basic
serializers for all the models we currently have.

We are using the adapter `json` with the root key `data`.

An example of a response object is as follows:

```
http :3000/v1/packages/1
HTTP/1.1 200 OK
Cache-Control: max-age=0, private, must-revalidate
Content-Type: application/json; charset=utf-8
ETag: W/"e44a2b843d4ec1f3a2daca64e0b67186"
Transfer-Encoding: chunked
Vary: Origin
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
X-Request-Id: 9aabb3d1-1f3e-4e8e-82fd-6a89ac73608a
X-Runtime: 0.040801
X-XSS-Protection: 1; mode=block

{
    data": {
	"crop_id": 438,
	"id": 1,
	"parent_id": null,
	"quantity": 4.86479785458857,
	"route_id": 732
    }
}

```

https://trello.com/c/Q4XbmnFI/